### PR TITLE
Update github actions to use node 16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,15 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.8"
-      - uses: pre-commit/action@v3.0.0
+      - name: install pre-commit
+        run: python -m pip install pre-commit
+      - name: get cached pre-commit hooks
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
+      - name: pre-commit checks
+        run: pre-commit run --show-diff-on-failure --color=always
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,6 +105,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: wheels
+          path: wheels
       - name: Create bin/
         run: mkdir -p bin
       - name: get MininZinc path to cache
@@ -206,6 +207,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: wheels
+          path: wheels
       - name: Create the github release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -217,10 +217,10 @@ jobs:
           name: wheels
           path: wheels
       - name: Create the github release
-        uses: softprops/action-gh-release@v1
+        uses: ncipollo/release-action@v1
         with:
-          files: wheels/*.whl
-          generate_release_notes: true
+          artifacts: wheels/*.whl
+          generateReleaseNotes: true
       - name: Publish package to TestPyPI (only for forks)
         env:
           TEST_PYPI_API_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,17 +18,17 @@ jobs:
   linters:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.8"
-      - uses: pre-commit/action@v2.0.0
+      - uses: pre-commit/action@v3.0.0
 
   build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install build dependencies
         run: pip install -U setuptools wheel
       - name: Update version number according to pushed tag
@@ -42,7 +42,7 @@ jobs:
       - name: Build discrete-optimization wheel
         run: python setup.py bdist_wheel
       - name: Upload as build artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: wheels
           path: dist/*.whl
@@ -96,13 +96,13 @@ jobs:
         shell: bash
     steps:
       - name: Checkout discrete-optimization source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Download artifacts
-        uses: actions/download-artifact@v1.0.0
+        uses: actions/download-artifact@v3
         with:
           name: wheels
       - name: Create bin/
@@ -113,7 +113,7 @@ jobs:
           echo "::set-output name=path::${{ matrix.minizinc_cache_path }}"
       - name: Restore MiniZinc cache
         id: cache-minizinc
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.get-mzn-cache-path.outputs.path }}
           key: ${{ matrix.minizinc_url }}
@@ -138,7 +138,7 @@ jobs:
           echo "::set-output name=dir::$(pip cache dir)"
       - name: Restore pip cache
         id: cache-pip
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.get-pip-cache-dir.outputs.dir }}
           key: pip-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('setup.py') }}
@@ -156,7 +156,7 @@ jobs:
           fi
       - name: Restore tests data cache
         id: cache-data
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/discrete_optimization_data
           key: data-${{ hashFiles('discrete_optimization/datasets.py') }}
@@ -203,7 +203,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Download wheels artifact
-        uses: actions/download-artifact@v1.0.0
+        uses: actions/download-artifact@v3
         with:
           name: wheels
       - name: Create the github release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,10 +162,9 @@ jobs:
           key: data-${{ hashFiles('discrete_optimization/datasets.py') }}
       - name: Fetch data for tests
         if: steps.cache-data.outputs.cache-hit != 'true'
-        shell: python3 {0}
         run: |
-          from discrete_optimization.datasets import fetch_all_datasets
-          fetch_all_datasets()
+          export PATH=$PATH:${{ matrix.minizinc_path }}
+          python -m discrete_optimization.datasets
       - name: Test with pytest (no coverage)
         if: ${{ !matrix.coverage }}
         run: |


### PR DESCRIPTION
Actions running on node 12 will not work anymore in summer 2023 and are
now raising warnings:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

So:
- we update when possible actions version to ones using node 16 instead of 12.
- we stop using deprecated pre-commit/action and replace it by simple call to pre-commit in a shell (mimicking pre-commit/action@v3)
- we replace softprops/action-gh-release by ncipollo/release-action@v1 which is using node 16